### PR TITLE
adjusted padding for desktop navigation

### DIFF
--- a/client/src/components/AppNavigation/DesktopNavigation/Navigation.tsx
+++ b/client/src/components/AppNavigation/DesktopNavigation/Navigation.tsx
@@ -20,6 +20,9 @@ export default Navigation;
 
 const NavContainer = styled.nav`
   display: flex;
+  @media (min-width: 769px) {
+    padding: 0 1rem;
+  }
 `;
 const NavList = styled.ul`
   list-style: none;

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -36,9 +36,9 @@ const HeaderContainer = styled.header`
     justify-content: space-between;
     align-items: center;
     border-bottom: 0.0625rem solid rgb(215, 215, 215);
-    padding: 12px 16px;
+    padding: 0.75rem 1rem;
     @media (min-width: 769px) {
-      padding: 12px 32px;
+      padding: 0.75rem 2rem;
     }
   }
 `;


### PR DESCRIPTION
After trying to use container class form tailwind, I discovered that there is no container class that has full width with some padding as do other frameworks (bootstrap...). 
To center a class with tailwind it is provided the "mx-auto" class and if needed padding.
So, I just adjusted spacing for header elements to match each other.